### PR TITLE
Bug Fix: If a project is deleted, any notes linked to that project will now be unlinked

### DIFF
--- a/source/backend/ProjectTable.js
+++ b/source/backend/ProjectTable.js
@@ -266,7 +266,7 @@ function appendLinkedNoteToProject(projectID, noteID) {
 function removeLinkedNoteFromProject(projectID, noteID) {
   const projectObject = getProjectFromTable(projectID);
   projectObject["linkedNotes"] = projectObject["linkedNotes"].filter(note => note !== noteID);
-  modifyLinkedProject(noteID,projectID);
+  modifyLinkedProject(noteID,"");
   saveProjectToTable(projectID, projectObject);
 }
 

--- a/source/project/editProject.js
+++ b/source/project/editProject.js
@@ -426,7 +426,6 @@ function populateLinkedNotes(linkedNotes, elementLinkedNotes) {
 
 function removeLinkedNote(noteID) {
   removeLinkedNoteFromProject(PROJECT_ID, noteID);
-  modifyLinkedProject(noteID, "");
   const linkedNotesElement = document.querySelector(".linkedNotes");
   const project = getProjectFromTable(PROJECT_ID);
   populateLinkedNotes(project.linkedNotes, linkedNotesElement);

--- a/source/project/viewProject.js
+++ b/source/project/viewProject.js
@@ -357,23 +357,6 @@ function populateLinkedNotes(linkedNotes, elementLinkedNotes) {
     elementLinkedNotes.appendChild(document.createElement("hr"));
   });
 
-  // Add event listener to trash icons
-  const trashIcons = elementLinkedNotes.querySelectorAll(".removeNote");
-  trashIcons.forEach((icon) => {
-    icon.addEventListener("click", () => {
-      const noteID = icon.getAttribute("id");
-      removeLinkedNote(noteID);
-    });
-  });
-}
-
-function removeLinkedNote(noteID) {
-  removeLinkedNoteFromProject(PROJECT_ID, noteID);
-  modifyLinkedProject(noteID, "");
-  const linkedNotesElement = document.querySelector(".linkedNotes");
-  const project = getProjectFromTable(PROJECT_ID);
-  populateLinkedNotes(project.linkedNotes, linkedNotesElement);
-  populateOptionsLinkNotes();
 }
 
 /**


### PR DESCRIPTION
### Main Fix:
- In ProjectTable.js I updated the deleteProjectFromTable function to modify all linkedProject values of any note linked to the deleted project to an empty string.

### Side changes:
- Updated the save button so there's not transition to view page
- Updated meta titles of project pages to "Commit | [Project Title]"
- Fixed some css inconsistencies between edit and view project

### Still needs fixing:
- Still auto saves new project if changing to new page